### PR TITLE
Implement packaging API

### DIFF
--- a/src/main/java/net/ubn/td/package_web/controller/PackageController.java
+++ b/src/main/java/net/ubn/td/package_web/controller/PackageController.java
@@ -1,0 +1,82 @@
+package net.ubn.td.package_web.controller;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.ubn.td.package_web.model.FileRecord;
+import net.ubn.td.package_web.model.PackageTask;
+import net.ubn.td.package_web.service.PackageService;
+
+@RestController
+@RequestMapping("/api")
+public class PackageController {
+
+    private final PackageService packageService;
+
+    public PackageController(PackageService packageService) {
+        this.packageService = packageService;
+    }
+
+    // 1. file upload
+    @PostMapping("/files/upload")
+    public ResponseEntity<?> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        FileRecord record = packageService.storeFile(file);
+        return ResponseEntity.ok(Map.of(
+                "fileId", record.getId(),
+                "fileName", record.getStoredName()
+        ));
+    }
+
+    // 2. get original file id by path
+    @GetMapping("/files/id")
+    public ResponseEntity<?> getFileId(@RequestParam("path") String path) {
+        return packageService.getFileByPath(path)
+                .<ResponseEntity<?>>map(r -> ResponseEntity.ok(Map.of("fileId", r.getId())))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // 3. list all original files
+    @GetMapping("/files")
+    public List<FileRecord> listFiles() {
+        return packageService.listFiles();
+    }
+
+    // 4. request packaging
+    @PostMapping("/tasks")
+    public ResponseEntity<?> requestTask(@RequestParam("fileId") Long fileId,
+                                         @RequestParam("packageType") String packageType) {
+        PackageTask task = packageService.requestPackage(fileId, packageType);
+        return ResponseEntity.ok(Map.of("taskId", task.getId()));
+    }
+
+    // 5. get status by fileId and packageType
+    @GetMapping("/status/file/{fileId}")
+    public ResponseEntity<?> statusByFile(@PathVariable Long fileId,
+                                          @RequestParam("packageType") String packageType) {
+        return packageService.getStatusByFile(fileId, packageType)
+                .<ResponseEntity<?>>map(t -> ResponseEntity.ok(Map.of(
+                        "status", t.getStatus(),
+                        "taskId", t.getId())))
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    // 6. get status by taskId
+    @GetMapping("/status/task/{taskId}")
+    public ResponseEntity<?> statusByTask(@PathVariable Long taskId) {
+        return packageService.getStatusByTask(taskId)
+                .<ResponseEntity<?>>map(t -> ResponseEntity.ok(Map.of(
+                        "status", t.getStatus(),
+                        "fileId", t.getFile().getId())))
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/net/ubn/td/package_web/model/FileRecord.java
+++ b/src/main/java/net/ubn/td/package_web/model/FileRecord.java
@@ -1,0 +1,46 @@
+package net.ubn.td.package_web.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class FileRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String storedName;
+
+    private String originalPath;
+
+    public FileRecord() {
+    }
+
+    public FileRecord(String storedName, String originalPath) {
+        this.storedName = storedName;
+        this.originalPath = originalPath;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getStoredName() {
+        return storedName;
+    }
+
+    public void setStoredName(String storedName) {
+        this.storedName = storedName;
+    }
+
+    public String getOriginalPath() {
+        return originalPath;
+    }
+
+    public void setOriginalPath(String originalPath) {
+        this.originalPath = originalPath;
+    }
+}

--- a/src/main/java/net/ubn/td/package_web/model/PackageTask.java
+++ b/src/main/java/net/ubn/td/package_web/model/PackageTask.java
@@ -1,0 +1,59 @@
+package net.ubn.td.package_web.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class PackageTask {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private FileRecord file;
+
+    private String packageType;
+
+    private String status;
+
+    public PackageTask() {
+    }
+
+    public PackageTask(FileRecord file, String packageType, String status) {
+        this.file = file;
+        this.packageType = packageType;
+        this.status = status;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public FileRecord getFile() {
+        return file;
+    }
+
+    public void setFile(FileRecord file) {
+        this.file = file;
+    }
+
+    public String getPackageType() {
+        return packageType;
+    }
+
+    public void setPackageType(String packageType) {
+        this.packageType = packageType;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/net/ubn/td/package_web/repository/FileRecordRepository.java
+++ b/src/main/java/net/ubn/td/package_web/repository/FileRecordRepository.java
@@ -1,0 +1,11 @@
+package net.ubn.td.package_web.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import net.ubn.td.package_web.model.FileRecord;
+
+public interface FileRecordRepository extends JpaRepository<FileRecord, Long> {
+    Optional<FileRecord> findByOriginalPath(String originalPath);
+}

--- a/src/main/java/net/ubn/td/package_web/repository/PackageTaskRepository.java
+++ b/src/main/java/net/ubn/td/package_web/repository/PackageTaskRepository.java
@@ -1,0 +1,13 @@
+package net.ubn.td.package_web.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import net.ubn.td.package_web.model.PackageTask;
+
+public interface PackageTaskRepository extends JpaRepository<PackageTask, Long> {
+    Optional<PackageTask> findFirstByFileIdAndPackageType(Long fileId, String packageType);
+    List<PackageTask> findByFileId(Long fileId);
+}

--- a/src/main/java/net/ubn/td/package_web/service/PackageService.java
+++ b/src/main/java/net/ubn/td/package_web/service/PackageService.java
@@ -1,0 +1,67 @@
+package net.ubn.td.package_web.service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import net.ubn.td.package_web.model.FileRecord;
+import net.ubn.td.package_web.model.PackageTask;
+import net.ubn.td.package_web.repository.FileRecordRepository;
+import net.ubn.td.package_web.repository.PackageTaskRepository;
+
+@Service
+@Transactional
+public class PackageService {
+
+    private final FileRecordRepository fileRecordRepository;
+    private final PackageTaskRepository packageTaskRepository;
+
+    private final Path uploadDir = Path.of("uploads");
+
+    public PackageService(FileRecordRepository fileRecordRepository,
+                          PackageTaskRepository packageTaskRepository) throws IOException {
+        this.fileRecordRepository = fileRecordRepository;
+        this.packageTaskRepository = packageTaskRepository;
+        if (!Files.exists(uploadDir)) {
+            Files.createDirectories(uploadDir);
+        }
+    }
+
+    public FileRecord storeFile(MultipartFile file) throws IOException {
+        String storedName = System.currentTimeMillis() + "_" + file.getOriginalFilename();
+        Path target = uploadDir.resolve(storedName);
+        Files.copy(file.getInputStream(), target, StandardCopyOption.REPLACE_EXISTING);
+        FileRecord record = new FileRecord(storedName, target.toString());
+        return fileRecordRepository.save(record);
+    }
+
+    public Optional<FileRecord> getFileByPath(String path) {
+        return fileRecordRepository.findByOriginalPath(path);
+    }
+
+    public List<FileRecord> listFiles() {
+        return fileRecordRepository.findAll();
+    }
+
+    public PackageTask requestPackage(Long fileId, String packageType) {
+        FileRecord file = fileRecordRepository.findById(fileId)
+                .orElseThrow(() -> new IllegalArgumentException("File not found"));
+        PackageTask task = new PackageTask(file, packageType, "PROCESSING");
+        return packageTaskRepository.save(task);
+    }
+
+    public Optional<PackageTask> getStatusByFile(Long fileId, String packageType) {
+        return packageTaskRepository.findFirstByFileIdAndPackageType(fileId, packageType);
+    }
+
+    public Optional<PackageTask> getStatusByTask(Long taskId) {
+        return packageTaskRepository.findById(taskId);
+    }
+}


### PR DESCRIPTION
## Summary
- add controller to handle file upload and packaging flow
- implement JPA entities `FileRecord` and `PackageTask`
- add repositories for database access
- create `PackageService` for core logic

## Testing
- `./mvnw -q test` *(fails: cannot open maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684f7ac9db68832d8aadca512c39ddab